### PR TITLE
Restrict the number of builds to keep

### DIFF
--- a/src/Spryker/Shared/SchedulerJenkins/SchedulerJenkinsConstants.php
+++ b/src/Spryker/Shared/SchedulerJenkins/SchedulerJenkinsConstants.php
@@ -49,4 +49,14 @@ interface SchedulerJenkinsConstants
      * @var string
      */
     public const JENKINS_DEFAULT_AMOUNT_OF_DAYS_FOR_LOGFILE_ROTATION = 'SCHEDULER_JENKINS:JENKINS_DEFAULT_AMOUNT_OF_DAYS_FOR_LOGFILE_ROTATION';
+
+    /**
+     * Specification:
+     * - Defines Jenkins builds to keep.
+     *
+     * @api
+     *
+     * @var string
+     */
+    public const JENKINS_DEFAULT_AMOUNT_OF_BUILDS_FOR_LOGFILE_ROTATION = 'SCHEDULER_JENKINS:JENKINS_DEFAULT_AMOUNT_OF_BUILDS_FOR_LOGFILE_ROTATION';
 }

--- a/src/Spryker/Zed/SchedulerJenkins/Business/TemplateGenerator/Template/jenkins-job.default.xml.twig
+++ b/src/Spryker/Zed/SchedulerJenkins/Business/TemplateGenerator/Template/jenkins-job.default.xml.twig
@@ -5,9 +5,9 @@
     {% block logRotator %}
     <logRotator>
         <daysToKeep>{{ job.payload.logrotate_days }}</daysToKeep>
-        <numToKeep>-1</numToKeep>
+        <numToKeep>{{ job.payload.num_builds_to_keep }}</numToKeep>
         <artifactDaysToKeep>{{ job.payload.logrotate_days }}</artifactDaysToKeep>
-        <artifactNumToKeep>-1</artifactNumToKeep>
+        <artifactNumToKeep>{{ job.payload.num_builds_to_keep }}</artifactNumToKeep>
     </logRotator>
     {% endblock logRotator %}
     <keepDependencies>false</keepDependencies>

--- a/src/Spryker/Zed/SchedulerJenkins/Business/TemplateGenerator/XmlJenkinsJobTemplateGenerator.php
+++ b/src/Spryker/Zed/SchedulerJenkins/Business/TemplateGenerator/XmlJenkinsJobTemplateGenerator.php
@@ -21,6 +21,11 @@ class XmlJenkinsJobTemplateGenerator implements JenkinsJobTemplateGeneratorInter
     /**
      * @var string
      */
+    protected const KEY_NUM_BUILDS_TO_KEEP = 'num_builds_to_keep';
+
+    /**
+     * @var string
+     */
     protected const KEY_JOB = 'job';
 
     /**
@@ -85,6 +90,12 @@ class XmlJenkinsJobTemplateGenerator implements JenkinsJobTemplateGeneratorInter
         }
 
         $jobPayload[static::KEY_LOG_ROTATE_DAYS] = $this->schedulerJenkinsConfig->getAmountOfDaysForLogFileRotation();
+        
+        if (array_key_exists(static::KEY_NUM_BUILDS_TO_KEEP, $jobPayload) && is_int($jobPayload[static::KEY_NUM_BUILDS_TO_KEEP])) {
+            return $jobTransfer;
+        }
+
+        $jobPayload[static::KEY_NUM_BUILDS_TO_KEEP] = $this->schedulerJenkinsConfig->getAmountOfBuildsForLogFileRotation();
 
         return $jobTransfer->setPayload($jobPayload);
     }

--- a/src/Spryker/Zed/SchedulerJenkins/SchedulerJenkinsConfig.php
+++ b/src/Spryker/Zed/SchedulerJenkins/SchedulerJenkinsConfig.php
@@ -18,6 +18,11 @@ class SchedulerJenkinsConfig extends AbstractBundleConfig
     protected const DEFAULT_AMOUNT_OF_DAYS_FOR_LOGFILE_ROTATION = 7;
 
     /**
+     * @var int
+     */
+    protected const DEFAULT_AMOUNT_OF_BUILDS_FOR_LOGFILE_ROTATION = 10;
+
+    /**
      * @var string
      */
     protected const DEFAULT_JENKINS_TEMPLATE_PATH = __DIR__ . '/Business/TemplateGenerator/Template/jenkins-job.default.xml.twig';
@@ -52,6 +57,16 @@ class SchedulerJenkinsConfig extends AbstractBundleConfig
     public function getAmountOfDaysForLogFileRotation(): int
     {
         return $this->get(SchedulerJenkinsConstants::JENKINS_DEFAULT_AMOUNT_OF_DAYS_FOR_LOGFILE_ROTATION, static::DEFAULT_AMOUNT_OF_DAYS_FOR_LOGFILE_ROTATION);
+    }
+
+    /**
+     * @api
+     *
+     * @return int
+     */
+    public function getAmountOfBuildsForLogFileRotation(): int
+    {
+        return $this->get(SchedulerJenkinsConstants::JENKINS_DEFAULT_AMOUNT_OF_BUILDS_FOR_LOGFILE_ROTATION, static::DEFAULT_AMOUNT_OF_BUILDS_FOR_LOGFILE_ROTATION);
     }
 
     /**


### PR DESCRIPTION
## PR Description

Currently jenkins keeps 7 days worth of builds. The issues here are

1. Some jobs, save big artifacts
2. Some jobs execute every minute

The result is that jenkins storage fills up. This can lead to the instance, or service being unavailable

This PR set the configuration for each job, to only keep 10 builds

![image](https://github.com/spryker/scheduler-jenkins/assets/104058340/02730e10-5ac0-486d-a836-4293186d0904)


## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
